### PR TITLE
chore: let Renovate open PRs before checks

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,6 @@
     "minimumReleaseAge": "3 days",
     "minimumReleaseAgeBehaviour": "timestamp-required",
     "internalChecksFilter": "strict",
-    "prCreation": "not-pending",
     "automerge": true,
     "automergeType": "pr",
     "automergeStrategy": "squash",


### PR DESCRIPTION
## Summary
- remove Renovate's prCreation=not-pending setting because this repo's required checks run on pull_request, not on Renovate's branch-only pushes
- avoids Renovate deadlocking branches in Dependency Dashboard pending checks before it can open PRs

## Validation
- python -m json.tool renovate.json
- docker run renovate/renovate:latest renovate-config-validator renovate.json