### PR TITLE
chore: prepare 0.11.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,11 @@ Available on github: https://github.com/tfehlmann/vscode-snakefmt-provider
 
 ## Release Notes
 
+### 0.11.2
+- Update bundled `snakefmt` to `2.0.2`
+- Fix Renovate PR creation so dependency updates are no longer blocked behind pending PR-only checks
+- Override vulnerable npm transitive dependencies and update `ujson` to resolve Dependabot alerts
+
 ### 0.11.1
 - Update npm and Python test dependencies to resolve Dependabot security alerts
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "snakefmt",
     "displayName": "Snakefmt",
     "description": "Linting and formatting support for snakemake files using `snakefmt`.",
-    "version": "0.11.1",
+    "version": "0.11.2",
     "packageManager": "pnpm@11.2.2",
     "preview": false,
     "serverInfo": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vscode-snakefmt-provider"
-version = "0.11.1"
+version = "0.11.2"
 requires-python = ">=3.11"
 dependencies = [
     "packaging==26.2",


### PR DESCRIPTION
## Summary
- bump extension and Python project version to 0.11.2
- add README release notes for the snakefmt 2.0.2 update, Renovate unblocking, and security dependency cleanup

## Verification
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm audit --prod=false --audit-level low`
- `corepack pnpm run lint`
- `corepack pnpm run package`
- `corepack pnpm run format-check`
- `/tmp/codex-uv-0.11.16/bin/uv run --frozen --group dev nox --session validate_readme`
