### PR TITLE
chore: schedule Renovate weekly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,8 @@
         "helpers:pinGitHubActionDigests"
     ],
     "labels": ["debt"],
+    "timezone": "America/Los_Angeles",
+    "schedule": ["before 5am on monday"],
     "minimumReleaseAge": "3 days",
     "minimumReleaseAgeBehaviour": "timestamp-required",
     "internalChecksFilter": "strict",
@@ -17,6 +19,10 @@
     "lockFileMaintenance": {
         "enabled": true,
         "automerge": true
+    },
+    "vulnerabilityAlerts": {
+        "enabled": true,
+        "addLabels": ["security"]
     },
     "packageRules": [
         {


### PR DESCRIPTION
## Summary
- restrict routine Renovate PR creation to before 5am Mondays in America/Los_Angeles
- explicitly keep vulnerability alert PRs enabled and add the `security` label

## Verification
- `python -m json.tool renovate.json`
- `docker run --rm --user "$(id -u):$(id -g)" -v "$PWD":/usr/src/app -w /usr/src/app renovate/renovate:latest renovate-config-validator renovate.json`

Renovate docs note that vulnerability alert PRs ignore `schedule` and rate limits, so security-related updates still skip the weekly window.
