### PR TITLE
chore: release 0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Change Log
+### 0.11.3
+- Update bundled `snakefmt` to `2.0.3`
+- Update CI and release tooling to `uv` `0.11.24`
+
+### 0.11.2
+- Update bundled `snakefmt` to `2.0.2`
+- Fix Renovate PR creation so dependency updates are no longer blocked behind pending PR-only checks
+- Override vulnerable npm transitive dependencies and update `ujson` to resolve Dependabot alerts
+
 ### 0.11.1
 - Update npm and Python test dependencies to resolve Dependabot security alerts
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ Available on github: https://github.com/tfehlmann/vscode-snakefmt-provider
 
 ## Release Notes
 
+### 0.11.3
+- Update bundled `snakefmt` to `2.0.3`
+- Update CI and release tooling to `uv` `0.11.24`
+
 ### 0.11.2
 - Update bundled `snakefmt` to `2.0.2`
 - Fix Renovate PR creation so dependency updates are no longer blocked behind pending PR-only checks

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "snakefmt",
     "displayName": "Snakefmt",
     "description": "Linting and formatting support for snakemake files using `snakefmt`.",
-    "version": "0.11.2",
+    "version": "0.11.3",
     "packageManager": "pnpm@11.8.0",
     "preview": false,
     "serverInfo": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vscode-snakefmt-provider"
-version = "0.11.2"
+version = "0.11.3"
 requires-python = ">=3.11"
 dependencies = [
     "packaging==26.2",

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "vscode-snakefmt-provider"
-version = "0.11.2"
+version = "0.11.3"
 source = { virtual = "." }
 dependencies = [
     { name = "packaging" },


### PR DESCRIPTION
## Summary
- bump extension and project version to 0.11.3
- add 0.11.3 release notes for bundled snakefmt 2.0.3
- keep CHANGELOG aligned with README release notes

## Verification
- uv 0.11.24: nox --session validate_readme
- uv 0.11.24: nox --session tests
- corepack pnpm run lint
- corepack pnpm exec vsce package --no-dependencies -o /tmp/snakefmt-0.11.3.vsix